### PR TITLE
fix: include character count and limit in 'Document is too long' error

### DIFF
--- a/functions/import_pipeline/import_pipeline.py
+++ b/functions/import_pipeline/import_pipeline.py
@@ -103,7 +103,12 @@ def import_arxiv_latex_and_pdf(
             raise
 
         if len(latex_string) > MAX_LATEX_CHARACTER_COUNT:
-            raise ValueError(f"Document is too long")
+            raise ValueError(
+                f"Document is too long: {len(latex_string):,} characters "
+                f"(limit is {MAX_LATEX_CHARACTER_COUNT:,}). "
+                f"Consider using a shorter version of the paper or "
+                f"splitting it into sections."
+            )
 
         if existing_model_output_file:
             with open(existing_model_output_file, "r") as file:


### PR DESCRIPTION
## Problem

When a paper's LaTeX source exceeds `MAX_LATEX_CHARACTER_COUNT` (300,000 characters), the import pipeline raises:

```
ValueError: Document is too long
```

This gives users **zero context** — they don't know how long their document is, what the limit is, or what they can do about it (see #130).

## Fix

The error message now includes:
- **Actual character count** of the document
- **Configured limit** (300,000)
- **Actionable suggestion** to use a shorter version or split into sections

### Before
```
ValueError: Document is too long
```

### After
```
ValueError: Document is too long: 487,234 characters (limit is 300,000).
Consider using a shorter version of the paper or splitting it into sections.
```

## Related Issues

Fixes #130